### PR TITLE
Idlm avengers

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -351,6 +351,7 @@ data class CodeGenConfig(
     /** If enabled, the names of the classes available via the DgsConstant class will be snake cased.*/
     val snakeCaseConstantNames: Boolean = false,
     val generateInterfaceSetters: Boolean = true,
+    val includeImports: Map<String, String> = emptyMap()
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -147,7 +147,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         const val TYPE = "type"
         const val NAME = "name"
         const val CUSTOM_ANNOTATION = "annotate"
-        const val PARAMETERS = "parameters"
+        const val INPUTS = "inputs"
         const val DOT = "."
     }
 
@@ -218,7 +218,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
      * Creates custom annotation with arguments
      * name -> Name of the class to be annotated. It will contain className with oor without the package name (Mandatory)
      * type -> The type of operation intended with this annotation. This value is also used to look up if there is any default packages associated with this annotation in the config
-     * parameters -> These are the input parameter needed for the annotation. If empty no parameters will be present for the annotation
+     * inputs -> These are the input parameters needed for the annotation. If empty no inputs will be present for the annotation
      */
     private fun createCustomAnnotation(directive: Directive): AnnotationSpec {
         val annotationArgumentMap: MutableMap<String, Value<Value<*>>> = mutableMapOf()
@@ -234,9 +234,9 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         )
         val className = ClassName(packageName = packageName, simpleNames = listOf(simpleName))
         val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
-        if (annotationArgumentMap.containsKey(ParserConstants.PARAMETERS)) {
+        if (annotationArgumentMap.containsKey(ParserConstants.INPUTS)) {
             val codeBlocks: MutableList<CodeBlock> = mutableListOf()
-            codeBlocks.addAll(parseParameter(annotationArgumentMap[ParserConstants.PARAMETERS] as ObjectValue))
+            codeBlocks.addAll(parseParameter(annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue))
             codeBlocks.forEach { codeBlock ->
                 annotation.addMember(codeBlock)
             }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -23,6 +23,7 @@ import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.filterSkipped
 import com.netflix.graphql.dgs.codegen.generators.java.InputTypeGenerator
 import com.netflix.graphql.dgs.codegen.shouldSkip
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -41,6 +42,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.lang.IllegalArgumentException
 import com.squareup.kotlinpoet.TypeName as KtTypeName
 
 class KotlinDataTypeGenerator(config: CodeGenConfig, document: Document) :
@@ -60,12 +62,12 @@ class KotlinDataTypeGenerator(config: CodeGenConfig, document: Document) :
         val fields = definition.fieldDefinitions
             .filterSkipped()
             .filter(ReservedKeywordFilter.filterInvalidNames)
-            .map { Field(it.name, typeUtils.findReturnType(it.type), typeUtils.isNullable(it.type), null, it.description) } +
+            .map { Field(it.name, typeUtils.findReturnType(it.type), typeUtils.isNullable(it.type), null, it.description, it.directives) } +
             extensions.flatMap { it.fieldDefinitions }
                 .filterSkipped()
-                .map { Field(it.name, typeUtils.findReturnType(it.type), typeUtils.isNullable(it.type), null, it.description) }
+                .map { Field(it.name, typeUtils.findReturnType(it.type), typeUtils.isNullable(it.type), null, it.description, it.directives) }
         val interfaces = definition.implements
-        return generate(definition.name, fields, interfaces, document, definition.description)
+        return generate(definition.name, fields, interfaces, document, definition.description, definition.directives)
     }
 
     override fun getPackageName(): String {
@@ -96,7 +98,7 @@ class KotlinInputTypeGenerator(config: CodeGenConfig, document: Document) :
                 }
             )
         val interfaces = emptyList<Type<*>>()
-        return generate(definition.name, fields, interfaces, document, definition.description)
+        return generate(definition.name, fields, interfaces, document, definition.description, definition.directives)
     }
 
     private fun generateCode(value: Value<Value<*>>, type: KtTypeName): CodeBlock =
@@ -129,7 +131,8 @@ internal data class Field(
     val type: KtTypeName,
     val nullable: Boolean,
     val default: CodeBlock? = null,
-    val description: Description? = null
+    val description: Description? = null,
+    val directives: List<Directive> = emptyList()
 )
 
 abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected val config: CodeGenConfig, protected val document: Document) {
@@ -139,12 +142,50 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         document = document
     )
 
+    private fun createAnnotations(directives: List<Directive>): MutableList<AnnotationSpec> {
+        // TODO fix the package name
+        var annotations: MutableList<AnnotationSpec> = mutableListOf()
+        directives.forEach { directive ->
+            if (directive.name == "validate") {
+                if (directive.arguments.isEmpty() || directive.arguments[0].name != "validator") {
+                    throw IllegalArgumentException("Invalid validate directive")
+                }
+                val className: ClassName = ClassName(packageName = (directive.arguments[0].value as EnumValue).name, simpleNames = listOf((directive.arguments[0].value as EnumValue).name))
+                val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
+                if (directive.arguments.size > 1) {
+                    directive.arguments.drop(1).forEach { argument ->
+                        when (argument.value) {
+                            is IntValue -> annotation.addMember(argument.name + " = %L", (argument.value as IntValue).value)
+                            is StringValue -> annotation.addMember(argument.name + " = %S", (argument.value as StringValue).value)
+                            is BooleanValue -> annotation.addMember(argument.name + " = %L", (argument.value as BooleanValue).isValue)
+                            is EnumValue -> annotation.addMember(CodeBlock.of(argument.name + "%M", MemberName(ClassName(packageName = (argument.value as EnumValue).name, simpleNames = listOf((argument.value as EnumValue).name)), (argument.value as EnumValue).name)))
+                            is FloatValue -> annotation.addMember(argument.name + " = %L", (argument.value as FloatValue).value)
+                            is ArrayValue -> annotation.addMember(argument.name + " = %L", (argument.value as ArrayValue).values)
+                            else -> annotation.addMember(argument.name + " = %L", (argument.value as StringValue).value)
+                        }
+                    }
+                }
+                annotations.add(annotation.build())
+            }
+        }
+        return annotations
+    }
+
+    private fun applyDirectives(directives: List<Directive>, parameterSpec: ParameterSpec.Builder) {
+        parameterSpec.addAnnotations(createAnnotations(directives))
+    }
+
+    private fun applyDirectives(directives: List<Directive>, typeSpec: TypeSpec.Builder) {
+        typeSpec.addAnnotations(createAnnotations(directives))
+    }
+
     internal fun generate(
         name: String,
         fields: List<Field>,
         interfaces: List<Type<*>>,
         document: Document,
-        description: Description? = null
+        description: Description? = null,
+        directives: List<Directive> = emptyList()
     ): CodeGenResult {
         val kotlinType = TypeSpec.classBuilder(name)
 
@@ -156,12 +197,20 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
             kotlinType.addKdoc("%L", description.sanitizeKdoc())
         }
 
+        if (directives.isNotEmpty()) {
+            applyDirectives(directives, kotlinType)
+        }
+
         val constructorBuilder = FunSpec.constructorBuilder()
 
         fields.forEach { field ->
             val returnType = if (field.nullable) field.type.copy(nullable = true) else field.type
             val parameterSpec = ParameterSpec.builder(field.name, returnType)
                 .addAnnotation(jsonPropertyAnnotation(field.name))
+
+            if (field.directives.isNotEmpty()) {
+                applyDirectives(field.directives, parameterSpec)
+            }
 
             if (field.default != null) {
                 parameterSpec.defaultValue(field.default)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -208,9 +208,8 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
      * Also parses the  simpleName/className from the name argument in the directive
      */
     private fun parsePackage(name: String, type: String? = null): Pair<String, String> {
-        val configPackageName = config.includeImports.getOrDefault(type, "")
         var packageName = name.substringBeforeLast(".", "")
-        packageName = if (packageName.isEmpty()) configPackageName else packageName
+        packageName = if (packageName.isEmpty() && type != null) config.includeImports.getOrDefault(type, "") else packageName
         return packageName to name.substringAfterLast(".")
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -215,7 +215,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
     }
 
     /**
-     * Creates custom annotation with arguments
+     * Creates custom annotation from arguments
      * name -> Name of the class to be annotated. It will contain className with oor without the package name (Mandatory)
      * type -> The type of operation intended with this annotation. This value is also used to look up if there is any default packages associated with this annotation in the config
      * inputs -> These are the input parameters needed for the annotation. If empty no inputs will be present for the annotation

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -146,7 +146,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         const val ASSIGNMENT_OPERATOR = " = "
         const val TYPE = "type"
         const val NAME = "name"
-        const val CUSTOM_ANNOTATION = "customAnnotation"
+        const val CUSTOM_ANNOTATION = "annotate"
         const val PARAMETERS = "parameters"
         const val DOT = "."
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -160,8 +160,6 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         directives.forEach { directive ->
             if (directive.name == "validate") {
                 annotations.add(createAnnotation(directive, config.includeImports.getOrDefault("validatorPackage", "")))
-            } else {
-                throw IllegalArgumentException("Unknown directive")
             }
         }
         return annotations

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -91,10 +91,10 @@ class KotlinInputTypeGenerator(config: CodeGenConfig, document: Document) :
             .map {
                 val type = typeUtils.findReturnType(it.type)
                 val defaultValue = it.defaultValue?.let { value -> generateCode(value, type) }
-                Field(name = it.name, type = type, nullable = typeUtils.isNullable(it.type), default = defaultValue, description = it.description)
+                Field(name = it.name, type = type, nullable = typeUtils.isNullable(it.type), default = defaultValue, description = it.description, directives = it.directives)
             }.plus(
                 extensions.flatMap { it.inputValueDefinitions }.map {
-                    Field(name = it.name, type = typeUtils.findReturnType(it.type), nullable = typeUtils.isNullable(it.type), default = null, description = it.description)
+                    Field(name = it.name, type = typeUtils.findReturnType(it.type), nullable = typeUtils.isNullable(it.type), default = null, description = it.description, directives = it.directives)
                 }
             )
         val interfaces = emptyList<Type<*>>()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -177,10 +177,10 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         }
 
     /**
-     * Parses the parameters argument in the directive to get the input parameters of the annotation
+     * Parses the inputs argument in the directive to get the input parameters of the annotation
      */
-    private fun parseParameter(parameters: ObjectValue): List<CodeBlock> {
-        val objectFields: List<ObjectField> = parameters.objectFields
+    private fun parseInputs(inputs: ObjectValue): List<CodeBlock> {
+        val objectFields: List<ObjectField> = inputs.objectFields
         val codeBlocks: MutableList<CodeBlock> = mutableListOf()
         objectFields.forEach() { objectField ->
             codeBlocks.add(generateCode(objectField.value, objectField.name + ParserConstants.ASSIGNMENT_OPERATOR))
@@ -226,7 +226,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
             annotationArgumentMap[argument.name] = argument.value
         }
         if (directive.arguments.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME) || (annotationArgumentMap[ParserConstants.NAME] as StringValue).value.isEmpty()) {
-            throw IllegalArgumentException("Invalid customAnnotation directive")
+            throw IllegalArgumentException("Invalid annotate directive")
         }
         val (packageName, simpleName) = parsePackage(
             (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
@@ -236,7 +236,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
         if (annotationArgumentMap.containsKey(ParserConstants.INPUTS)) {
             val codeBlocks: MutableList<CodeBlock> = mutableListOf()
-            codeBlocks.addAll(parseParameter(annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue))
+            codeBlocks.addAll(parseInputs(annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue))
             codeBlocks.forEach { codeBlock ->
                 annotation.addMember(codeBlock)
             }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -145,22 +145,23 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
     /**
      * Generates the code block containing the parameters of an annotation in the format key = value
      */
-    private fun generateCode(value: Value<Value<*>>, prefix: String = ""): CodeBlock =
+    private fun generateCode(value: Value<Value<*>>, prefix: String = "", enumType: String = ""): CodeBlock =
         when (value) {
             is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
             is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
             is StringValue -> CodeBlock.of("$prefix%S", (value as StringValue).value)
             is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
+            // If an enum value the prefix/enumType (key in the parameters map for the enum) is used to get the package name from the config
             is EnumValue -> CodeBlock.of(
                 "$prefix%M",
                 MemberName(
-                    config.includeImports.getOrDefault(prefix.substringBefore(" = "), ""),
+                    if (prefix.isNotEmpty()) config.includeImports.getOrDefault(prefix.substringBefore(" = "), "") else config.includeImports.getOrDefault(enumType.substringBefore(" = "), ""),
                     (value as EnumValue).name
                 )
             )
             is ArrayValue ->
                 if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("emptyList()")
-                else CodeBlock.of("$prefix[%L]", (value as ArrayValue).values.joinToString { v -> generateCode(v).toString() })
+                else CodeBlock.of("$prefix[%L]", (value as ArrayValue).values.joinToString { v -> generateCode(value = v, enumType = if (v is EnumValue) prefix else "").toString() })
             else -> CodeBlock.of("$prefix%L", value)
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -225,12 +225,12 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         directive.arguments.forEach { argument ->
             annotationArgumentMap[argument.name] = argument.value
         }
-        if (directive.arguments.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME) || (annotationArgumentMap[ParserConstants.NAME] as StringValue).value.isEmpty()) {
+        if (directive.arguments.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME) || annotationArgumentMap[ParserConstants.NAME] is NullValue || (annotationArgumentMap[ParserConstants.NAME] as StringValue).value.isEmpty()) {
             throw IllegalArgumentException("Invalid annotate directive")
         }
         val (packageName, simpleName) = parsePackage(
             (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
-            if (annotationArgumentMap.containsKey(ParserConstants.TYPE)) (annotationArgumentMap[ParserConstants.TYPE] as StringValue).value else null
+            if (annotationArgumentMap.containsKey(ParserConstants.TYPE) && annotationArgumentMap[ParserConstants.TYPE] !is NullValue) (annotationArgumentMap[ParserConstants.TYPE] as StringValue).value else null
         )
         val className = ClassName(packageName = packageName, simpleNames = listOf(simpleName))
         val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -225,7 +225,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         directive.arguments.forEach { argument ->
             annotationArgumentMap[argument.name] = argument.value
         }
-        if (directive.arguments.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME)) {
+        if (directive.arguments.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME) || (annotationArgumentMap[ParserConstants.NAME] as StringValue).value.isEmpty()) {
             throw IllegalArgumentException("Invalid customAnnotation directive")
         }
         val (packageName, simpleName) = parsePackage(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -171,9 +171,10 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         if (directive.arguments.isEmpty() || directive.arguments[0].name != "name") {
             throw IllegalArgumentException("Invalid validate directive")
         }
-        var packageName = (directive.arguments[0].value as StringValue).value.substringBeforeLast(".", "")
-        packageName = if (packageName.isEmpty()) configPackageName else packageName
-        val className: ClassName = ClassName(packageName = packageName, simpleNames = listOf((directive.arguments[0].value as StringValue).value.substringAfterLast(".", (directive.arguments[0].value as StringValue).value)))
+        val wholePackageName = (directive.arguments[0].value as StringValue).value
+        val packageName = if (wholePackageName.substringBeforeLast(".", "").isEmpty()) configPackageName else wholePackageName.substringBeforeLast(".")
+        val simpleName = wholePackageName.substringAfterLast(".")
+        val className: ClassName = ClassName(packageName = packageName, simpleNames = listOf(simpleName))
         val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
         if (directive.arguments.size > 1) {
             directive.arguments.drop(1).forEach { argument ->

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -160,24 +160,28 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
         var annotations: MutableList<AnnotationSpec> = mutableListOf()
         directives.forEach { directive ->
             if (directive.name == "validate") {
-                if (directive.arguments.isEmpty() || directive.arguments[0].name != "name") {
-                    throw IllegalArgumentException("Invalid validate directive")
-                }
-                val className: ClassName = ClassName(packageName = (directive.arguments[0].value as EnumValue).name, simpleNames = listOf((directive.arguments[0].value as EnumValue).name))
-                val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
-                if (directive.arguments.size > 1) {
-                    directive.arguments.drop(1).forEach { argument ->
-                        val className: ClassName? = if (argument.value is EnumValue) ClassName(packageName = (argument.value as EnumValue).name, simpleNames = listOf((argument.value as EnumValue).name)) else null
-                        val codeBlock: CodeBlock = generateCode(argument.value, className, argument.name + " = ")
-                        annotation.addMember(codeBlock)
-                    }
-                }
-                annotations.add(annotation.build())
+                annotations.add(createAnnotation(directive))
             } else {
                 throw IllegalArgumentException("Unknown directive")
             }
         }
         return annotations
+    }
+
+    private fun createAnnotation(directive: Directive): AnnotationSpec {
+        if (directive.arguments.isEmpty() || directive.arguments[0].name != "name") {
+            throw IllegalArgumentException("Invalid validate directive")
+        }
+        val className: ClassName = ClassName(packageName = (directive.arguments[0].value as EnumValue).name, simpleNames = listOf((directive.arguments[0].value as EnumValue).name))
+        val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
+        if (directive.arguments.size > 1) {
+            directive.arguments.drop(1).forEach { argument ->
+                val className: ClassName? = if (argument.value is EnumValue) ClassName(packageName = (argument.value as EnumValue).name, simpleNames = listOf((argument.value as EnumValue).name)) else null
+                val codeBlock: CodeBlock = generateCode(argument.value, className, argument.name + " = ")
+                annotation.addMember(codeBlock)
+            }
+        }
+        return annotation.build()
     }
 
     private fun applyDirectives(directives: List<Directive>, parameterSpec: ParameterSpec.Builder) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -151,7 +151,7 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
             is EnumValue -> CodeBlock.of("$prefix%M", className?.let { MemberName(it, (value as EnumValue).name) })
             is ArrayValue ->
                 if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("emptyList()")
-                else CodeBlock.of(prefix + "listOf(%L)", (value as ArrayValue).values.joinToString { v -> generateCode(v, className).toString() })
+                else CodeBlock.of("$prefix[%L]", (value as ArrayValue).values.joinToString { v -> generateCode(v, className).toString() })
             else -> CodeBlock.of("$prefix%L", value)
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -37,6 +37,20 @@ import graphql.language.StringValue
 import graphql.language.Value
 import java.lang.IllegalArgumentException
 
+object ParserConstants {
+    const val ASSIGNMENT_OPERATOR = " = "
+    const val TYPE = "type"
+    const val NAME = "name"
+    const val REASON = "reason"
+    const val CUSTOM_ANNOTATION = "annotate"
+    const val DEPRECATED = "deprecated"
+    const val INPUTS = "inputs"
+    const val DOT = "."
+    const val REPLACE_WITH_STR = ", replace with "
+    const val MESSAGE = "message"
+    const val REPLACE_WITH = "replaceWith"
+}
+
 /**
  * Generate a [JsonTypeInfo] annotation, which allows for Jackson
  * polymorphic type handling when deserializing from JSON.
@@ -122,9 +136,13 @@ fun jsonPropertyAnnotation(name: String): AnnotationSpec {
 }
 
 fun deprecatedAnnotation(reason: String): AnnotationSpec {
-    return AnnotationSpec.builder(Deprecated::class)
-        .addMember("%S", reason)
-        .build()
+    val replace = reason.substringAfter(ParserConstants.REPLACE_WITH_STR, "")
+    val builder: AnnotationSpec.Builder = AnnotationSpec.builder(Deprecated::class)
+        .addMember("${ParserConstants.MESSAGE}${ParserConstants.ASSIGNMENT_OPERATOR}%S", reason.substringBefore(ParserConstants.REPLACE_WITH_STR))
+    if (replace.isNotEmpty()) {
+        builder.addMember("${ParserConstants.REPLACE_WITH}${ParserConstants.ASSIGNMENT_OPERATOR}%S", reason.substringAfter(ParserConstants.REPLACE_WITH_STR))
+    }
+    return builder.build()
 }
 
 fun Description.sanitizeKdoc(): String {
@@ -173,17 +191,6 @@ private fun ktTypeClassBestGuess(name: String): ClassName {
         DOUBLE_ARRAY.simpleName -> DOUBLE_ARRAY
         else -> ClassName.bestGuess(name)
     }
-}
-
-object ParserConstants {
-    const val ASSIGNMENT_OPERATOR = " = "
-    const val TYPE = "type"
-    const val NAME = "name"
-    const val REASON = "reason"
-    const val CUSTOM_ANNOTATION = "annotate"
-    const val DEPRECATED = "deprecated"
-    const val INPUTS = "inputs"
-    const val DOT = "."
 }
 
 /**

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -27,7 +27,6 @@ import graphql.introspection.Introspection
 import graphql.language.ArrayValue
 import graphql.language.BooleanValue
 import graphql.language.Description
-import graphql.language.Directive
 import graphql.language.EnumValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
@@ -244,7 +243,7 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, prefix: 
 private fun parseInputs(config: CodeGenConfig, inputs: ObjectValue): List<CodeBlock> {
     val objectFields: List<ObjectField> = inputs.objectFields
     return objectFields.fold(mutableListOf(), {
-            codeBlocks, objectField ->
+        codeBlocks, objectField ->
         codeBlocks.add(generateCode(config, objectField.value, objectField.name + ParserConstants.ASSIGNMENT_OPERATOR))
         codeBlocks
     })

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -49,6 +49,7 @@ object ParserConstants {
     const val REPLACE_WITH_STR = ", replace with "
     const val MESSAGE = "message"
     const val REPLACE_WITH = "replaceWith"
+    const val REPLACE_WITH_CLASS = "ReplaceWith"
 }
 
 /**
@@ -136,11 +137,12 @@ fun jsonPropertyAnnotation(name: String): AnnotationSpec {
 }
 
 fun deprecatedAnnotation(reason: String): AnnotationSpec {
+    // TODO support for level
     val replace = reason.substringAfter(ParserConstants.REPLACE_WITH_STR, "")
     val builder: AnnotationSpec.Builder = AnnotationSpec.builder(Deprecated::class)
         .addMember("${ParserConstants.MESSAGE}${ParserConstants.ASSIGNMENT_OPERATOR}%S", reason.substringBefore(ParserConstants.REPLACE_WITH_STR))
     if (replace.isNotEmpty()) {
-        builder.addMember("${ParserConstants.REPLACE_WITH}${ParserConstants.ASSIGNMENT_OPERATOR}%S", reason.substringAfter(ParserConstants.REPLACE_WITH_STR))
+        builder.addMember(CodeBlock.of("${ParserConstants.REPLACE_WITH}${ParserConstants.ASSIGNMENT_OPERATOR}%M(%S)", MemberName("kotlin", ParserConstants.REPLACE_WITH_CLASS), reason.substringAfter(ParserConstants.REPLACE_WITH_STR)))
     }
     return builder.build()
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -21,9 +21,23 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.squareup.kotlinpoet.*
 import graphql.introspection.Introspection
+import graphql.language.ArrayValue
+import graphql.language.BooleanValue
 import graphql.language.Description
+import graphql.language.Directive
+import graphql.language.EnumValue
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.NullValue
+import graphql.language.ObjectField
+import graphql.language.ObjectValue
+import graphql.language.StringValue
+import graphql.language.Value
+import java.lang.IllegalArgumentException
+
 /**
  * Generate a [JsonTypeInfo] annotation, which allows for Jackson
  * polymorphic type handling when deserializing from JSON.
@@ -160,4 +174,90 @@ private fun ktTypeClassBestGuess(name: String): ClassName {
         DOUBLE_ARRAY.simpleName -> DOUBLE_ARRAY
         else -> ClassName.bestGuess(name)
     }
+}
+
+object ParserConstants {
+    const val ASSIGNMENT_OPERATOR = " = "
+    const val TYPE = "type"
+    const val NAME = "name"
+    const val REASON = "reason"
+    const val CUSTOM_ANNOTATION = "annotate"
+    const val DEPRECATED = "deprecated"
+    const val INPUTS = "inputs"
+    const val DOT = "."
+}
+
+/**
+ * Creates custom annotation from arguments
+ * name -> Name of the class to be annotated. It will contain className with oor without the package name (Mandatory)
+ * type -> The type of operation intended with this annotation. This value is also used to look up if there is any default packages associated with this annotation in the config
+ * inputs -> These are the input parameters needed for the annotation. If empty no inputs will be present for the annotation
+ */
+fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>, config: CodeGenConfig): AnnotationSpec {
+    if (annotationArgumentMap.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME) || annotationArgumentMap[ParserConstants.NAME] is NullValue || (annotationArgumentMap[ParserConstants.NAME] as StringValue).value.isEmpty()) {
+        throw IllegalArgumentException("Invalid annotate directive")
+    }
+    val (packageName, simpleName) = parsePackage(
+        config,
+        (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
+        if (annotationArgumentMap.containsKey(ParserConstants.TYPE) && annotationArgumentMap[ParserConstants.TYPE] !is NullValue) (annotationArgumentMap[ParserConstants.TYPE] as StringValue).value else null
+    )
+    val className = ClassName(packageName = packageName, simpleNames = listOf(simpleName))
+    val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
+    if (annotationArgumentMap.containsKey(ParserConstants.INPUTS)) {
+        val codeBlocks: List<CodeBlock> = parseInputs(config, annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue)
+        codeBlocks.forEach { codeBlock ->
+            annotation.addMember(codeBlock)
+        }
+    }
+    return annotation.build()
+}
+
+/**
+ * Generates the code block containing the parameters of an annotation in the format key = value
+ */
+private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, prefix: String = "", type: String = ""): CodeBlock =
+    when (value) {
+        is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
+        is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
+        is StringValue -> CodeBlock.of("$prefix%S", (value as StringValue).value)
+        is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
+        // If an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
+        // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.
+        is EnumValue -> CodeBlock.of(
+            "$prefix%M",
+            MemberName(
+                if (prefix.isNotEmpty()) config.includeImports.getOrDefault(prefix.substringBefore(ParserConstants.ASSIGNMENT_OPERATOR), "")
+                else config.includeImports.getOrDefault(type.substringBefore(ParserConstants.ASSIGNMENT_OPERATOR), ""),
+                (value as EnumValue).name
+            )
+        )
+        is ArrayValue ->
+            if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("[]")
+            else CodeBlock.of("$prefix[%L]", (value as ArrayValue).values.joinToString { v -> generateCode(config = config, value = v, type = if (v is EnumValue) prefix else "").toString() })
+        else -> CodeBlock.of("$prefix%L", value)
+    }
+
+/**
+ * Parses the inputs argument in the directive to get the input parameters of the annotation
+ */
+private fun parseInputs(config: CodeGenConfig, inputs: ObjectValue): List<CodeBlock> {
+    val objectFields: List<ObjectField> = inputs.objectFields
+    return objectFields.fold(mutableListOf(), {
+            codeBlocks, objectField ->
+        codeBlocks.add(generateCode(config, objectField.value, objectField.name + ParserConstants.ASSIGNMENT_OPERATOR))
+        codeBlocks
+    })
+}
+
+/**
+ * Parses the package value in the directive.
+ * If not present uses the default package in the config for that particular type of annotation.
+ * If neither of them are supplied the package name will be an empty String
+ * Also parses the  simpleName/className from the name argument in the directive
+ */
+private fun parsePackage(config: CodeGenConfig, name: String, type: String? = null): Pair<String, String> {
+    var packageName = name.substringBeforeLast(".", "")
+    packageName = if (packageName.isEmpty() && type != null) config.includeImports.getOrDefault(type, "") else packageName
+    return packageName to name.substringAfterLast(".")
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -108,6 +108,12 @@ fun jsonPropertyAnnotation(name: String): AnnotationSpec {
         .build()
 }
 
+fun deprecatedAnnotation(reason: String): AnnotationSpec {
+    return AnnotationSpec.builder(Deprecated::class)
+        .addMember("%S", reason)
+        .build()
+}
+
 fun Description.sanitizeKdoc(): String {
     return this.content.lineSequence().joinToString("\n")
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1673,7 +1673,7 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypes() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", maxLimit: 10, types: ["husband", "wife"]) {
+            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
                 name: String @customAnnotation(name: "ValidName", type: "validator")
             }
         """.trimIndent()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1673,7 +1673,7 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypes() {
         val schema = """
-            type Person @validate(name: ValidPerson, maxLimit: 10) {
+            type Person @validate(name: ValidPerson, maxLimit: 10, types: ["husband", "wife"]) {
                 name: String @validate(name: ValidName)
             }
         """.trimIndent()
@@ -1694,7 +1694,10 @@ class KotlinCodeGenTest {
                 |import com.fasterxml.jackson.`annotation`.JsonProperty
                 |import kotlin.String
                 |
-                |@ValidPerson(maxLimit = 10)
+                |@ValidPerson(
+                |  maxLimit = 10,
+                |  types = ["husband", "wife"]
+                |)
                 |public data class Person(
                 |  @JsonProperty("name")
                 |  @ValidName

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1673,8 +1673,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypes() {
         val schema = """
-            type Person @validate(validator: ValidPerson, maxLimit: 10) {
-                name: String @validate(validator: ValidName)
+            type Person @validate(name: ValidPerson, maxLimit: 10) {
+                name: String @validate(name: ValidName)
             }
         """.trimIndent()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1673,8 +1673,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypes() {
         val schema = """
-            type Person @validate(name: "ValidPerson", maxLimit: 10, types: ["husband", "wife"]) {
-                name: String @validate(name: "ValidName")
+            type Person @customAnnotation(name: "ValidPerson", type: "validator", maxLimit: 10, types: ["husband", "wife"]) {
+                name: String @customAnnotation(name: "ValidName", type: "validator")
             }
         """.trimIndent()
 
@@ -1713,8 +1713,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypesWithDefaultPackage() {
         val schema = """
-            type Person @validate(name: "ValidPerson", maxLimit: 10, types: ["husband", "wife"]) {
-                name: String @validate(name: "com.test.anotherValidator.ValidName")
+            type Person @customAnnotation(name: "ValidPerson", type: "validator", maxLimit: 10, types: ["husband", "wife"]) {
+                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName", type: "validator")
             }
         """.trimIndent()
 
@@ -1723,7 +1723,7 @@ class KotlinCodeGenTest {
                 schemas = setOf(schema),
                 packageName = basePackageName,
                 language = Language.KOTLIN,
-                includeImports = mapOf(Pair("validatorPackage", "com.test.validator"))
+                includeImports = mapOf(Pair("validator", "com.test.validator"))
             )
         ).generate().kotlinDataTypes
         assertThat(dataTypes[0].toString()).isEqualTo(

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2010,7 +2010,7 @@ class KotlinCodeGenTest {
     fun annotateOnTypesWithMultipleAnnotations() {
         val schema = """
             type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
-                name: String @annotate(name: "com.test.anotherValidator.ValidName"), @annotate(name: "com.test.nullValidator.NullValue")
+                name: String @annotate(name: "com.test.anotherValidator.ValidName") @annotate(name: "com.test.nullValidator.NullValue")
             }
         """.trimIndent()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1691,6 +1691,7 @@ class KotlinCodeGenTest {
                 |
                 |import com.fasterxml.jackson.`annotation`.JsonProperty
                 |import kotlin.Deprecated
+                |import kotlin.ReplaceWith
                 |import kotlin.String
                 |
                 |@Deprecated(message = "This is going bye bye")
@@ -1698,7 +1699,7 @@ class KotlinCodeGenTest {
                 |  @JsonProperty("name")
                 |  @Deprecated(
                 |    message = "This field is no longer available",
-                |    replaceWith = "firstName"
+                |    replaceWith = ReplaceWith("firstName")
                 |  )
                 |  public val name: String? = null
                 |) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1713,8 +1713,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypesWithDefaultPackage() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", maxLimit: 10, types: ["husband", "wife"]) {
-                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName", type: "validator")
+            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
+                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1673,8 +1673,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypes() {
         val schema = """
-            type Person @validate(name: ValidPerson, maxLimit: 10, types: ["husband", "wife"]) {
-                name: String @validate(name: ValidName)
+            type Person @validate(name: "ValidPerson", maxLimit: 10, types: ["husband", "wife"]) {
+                name: String @validate(name: "ValidName")
             }
         """.trimIndent()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1673,8 +1673,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypes() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
-                name: String @customAnnotation(name: "ValidName", type: "validator")
+            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
+                name: String @annotate(name: "ValidName", type: "validator")
             }
         """.trimIndent()
 
@@ -1713,8 +1713,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypesWithDefaultPackage() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
-                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName")
+            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
 
@@ -1754,8 +1754,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypesWithEnums() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {sexType: MALE}) {
-                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName")
+            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {sexType: MALE}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
 
@@ -1793,8 +1793,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypesWithListOfEnums() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
-                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName")
+            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
 
@@ -1831,8 +1831,8 @@ class KotlinCodeGenTest {
     @Test
     fun validationOnTypesWithMultipleAnnotations() {
         val schema = """
-            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
-                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName"), @customAnnotation(name: "com.test.nullValidator.NullValue")
+            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName"), @annotate(name: "com.test.nullValidator.NullValue")
             }
         """.trimIndent()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1674,7 +1674,7 @@ class KotlinCodeGenTest {
     fun deprecateAnnotation() {
         val schema = """
             input Person @deprecated(reason: "This is going bye bye") {
-                name: String @deprecated(reason: "This field is no longer available")
+                name: String @deprecated(reason: "This field is no longer available, replace with firstName")
             }
         """.trimIndent()
 
@@ -1693,10 +1693,13 @@ class KotlinCodeGenTest {
                 |import kotlin.Deprecated
                 |import kotlin.String
                 |
-                |@Deprecated("This is going bye bye")
+                |@Deprecated(message = "This is going bye bye")
                 |public data class Person(
                 |  @JsonProperty("name")
-                |  @Deprecated("This field is no longer available")
+                |  @Deprecated(
+                |    message = "This field is no longer available",
+                |    replaceWith = "firstName"
+                |  )
                 |  public val name: String? = null
                 |) {
                 |  public companion object

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1889,6 +1889,26 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun annotateOnTypesWithEmptyName() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
+                name: String @annotate(name: "")
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    language = Language.KOTLIN,
+                    includeImports = mapOf(Pair("validator", "com.test.validator"), Pair("types", "com.enums"))
+                )
+            ).generate()
+        }
+    }
+
+    @Test
     fun skipCodegenOnFields() {
         val schema = """
             type Person {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1791,6 +1791,44 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun validationOnTypesWithListOfEnums() {
+        val schema = """
+            type Person @customAnnotation(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
+                name: String @customAnnotation(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val dataTypes = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                includeImports = mapOf(Pair("validator", "com.test.validator"), Pair("types", "com.enums"))
+            )
+        ).generate().kotlinDataTypes
+        assertThat(dataTypes[0].toString()).isEqualTo(
+            """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types
+                |
+                |import com.fasterxml.jackson.`annotation`.JsonProperty
+                |import com.test.anotherValidator.ValidName
+                |import com.test.validator.ValidPerson
+                |import kotlin.String
+                |
+                |@ValidPerson(types = [com.enums.HUSBAND, com.enums.WIFE])
+                |public data class Person(
+                |  @JsonProperty("name")
+                |  @ValidName
+                |  public val name: String? = null
+                |) {
+                |  public companion object
+                |}
+
+        """.trimMargin()
+        )
+    }
+
+    @Test
     fun skipCodegenOnFields() {
         val schema = """
             type Person {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1671,9 +1671,9 @@ class KotlinCodeGenTest {
     }
 
     @Test
-    fun validationOnTypes() {
+    fun annotateOnTypes() {
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {maxLimit: 10, types: ["husband", "wife"]}) {
                 name: String @annotate(name: "ValidName", type: "validator")
             }
         """.trimIndent()
@@ -1711,9 +1711,9 @@ class KotlinCodeGenTest {
     }
 
     @Test
-    fun validationOnTypesWithDefaultPackage() {
+    fun annotateOnTypesWithDefaultPackage() {
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {maxLimit: 10, types: ["husband", "wife"]}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {maxLimit: 10, types: ["husband", "wife"]}) {
                 name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
@@ -1752,9 +1752,9 @@ class KotlinCodeGenTest {
     }
 
     @Test
-    fun validationOnTypesWithEnums() {
+    fun annotateOnTypesWithEnums() {
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {sexType: MALE}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {sexType: MALE}) {
                 name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
@@ -1791,9 +1791,9 @@ class KotlinCodeGenTest {
     }
 
     @Test
-    fun validationOnTypesWithListOfEnums() {
+    fun annotateOnTypesWithListOfEnums() {
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
                 name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()
@@ -1829,9 +1829,9 @@ class KotlinCodeGenTest {
     }
 
     @Test
-    fun validationOnTypesWithMultipleAnnotations() {
+    fun annotateOnTypesWithMultipleAnnotations() {
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", parameters: {types: [HUSBAND, WIFE]}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
                 name: String @annotate(name: "com.test.anotherValidator.ValidName"), @annotate(name: "com.test.nullValidator.NullValue")
             }
         """.trimIndent()
@@ -1866,6 +1866,26 @@ class KotlinCodeGenTest {
 
         """.trimMargin()
         )
+    }
+
+    @Test
+    fun annotateOnTypesWithoutName() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
+                name: String @annotate
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    language = Language.KOTLIN,
+                    includeImports = mapOf(Pair("validator", "com.test.validator"), Pair("types", "com.enums"))
+                )
+            ).generate()
+        }
     }
 
     @Test


### PR DESCRIPTION
Custom annotate directive to support custom annotations.
Deprecated directive
Sample grahqls:
```
input Person @deprecated(reason: "This is going bye bye") {
    name: String @deprecated(reason: "This field is no longer available, replace with firstName")
}
```
Sample class created:
```
package com.netflix.graphql.dgs.codegen.tests.generated.types
                
import com.fasterxml.jackson.`annotation`.JsonProperty
import kotlin.Deprecated
import kotlin.ReplaceWith
import kotlin.String

@Deprecated(message = "This is going bye bye")
public data class Person(
  @JsonProperty("name")
  @Deprecated(
    message = "This field is no longer available",
    replaceWith = ReplaceWith("firstName")
  )
  public val name: String? = null
) {
  public companion object
}
```

Custom annotate directive:
Sample grahqls:
```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
    name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```
Sample class created:
```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import kotlin.String

@ValidPerson(types = [com.enums.HUSBAND, com.enums.WIFE])
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null
) {
  public companion object
}
```