### PR TITLE
IIEA-10827 support class objects as inputs

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -472,6 +472,7 @@ data class CodeGenConfig(
     val generateInterfaceSetters: Boolean = true,
     val includeImports: Map<String, String> = emptyMap(),
     val includeEnumImports: Map<String, Map<String, String>> = emptyMap(),
+    val includeClassImports:  Map<String, Map<String, String>> = emptyMap(),
     val generateCustomAnnotations: Boolean = false,
     var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -472,7 +472,7 @@ data class CodeGenConfig(
     val generateInterfaceSetters: Boolean = true,
     val includeImports: Map<String, String> = emptyMap(),
     val includeEnumImports: Map<String, Map<String, String>> = emptyMap(),
-    val includeClassImports:  Map<String, Map<String, String>> = emptyMap(),
+    val includeClassImports: Map<String, Map<String, String>> = emptyMap(),
     val generateCustomAnnotations: Boolean = false,
     var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -195,8 +195,10 @@ fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>,
         val objectFields: List<ObjectField> = (annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue).objectFields
         for (objectField in objectFields) {
             val codeBlock: CodeBlock = generateCode(
+                config,
                 objectField.value,
-                PackageParserUtil.getEnumPackage(config, (annotationArgumentMap[ParserConstants.NAME] as StringValue).value, objectField.name)
+                (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
+                objectField.name
             )
             annotation.addMember(objectField.name, codeBlock)
         }
@@ -207,21 +209,31 @@ fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>,
 /**
  * Generates the code block containing the parameters of an annotation in the format value
  */
-private fun generateCode(value: Value<Value<*>>, packageName: String = ""): CodeBlock =
+private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotationName: String, prefix: String = ""): CodeBlock =
     when (value) {
         is BooleanValue -> CodeBlock.of("\$L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("\$L", (value as IntValue).value)
-        is StringValue -> CodeBlock.of("\$S", (value as StringValue).value)
+        is StringValue ->
+            // If string ends with .class, treat as class object
+            if ((value as StringValue).value.takeLast(6) == ".class") {
+                val className = (value as StringValue).value.dropLast(6)
+                // Use annotationName and className in the PackagerParserUtil to get Class Package name.
+                CodeBlock.of(
+                    "\$T.class",
+                    ClassName.get(PackageParserUtil.getClassPackage(config, annotationName, className), className)
+                )
+            }
+            else CodeBlock.of("\$S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("\$L", (value as FloatValue).value)
-        // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
+        // In an enum value the prefix (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.
         is EnumValue -> CodeBlock.of(
             "\$T",
-            ClassName.get(packageName, (value as EnumValue).name)
+            ClassName.get(PackageParserUtil.getEnumPackage(config, annotationName, prefix), (value as EnumValue).name)
         )
         is ArrayValue ->
             if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("[]")
-            else CodeBlock.of("[\$L]", (value as ArrayValue).values.joinToString { v -> generateCode(value = v, if (v is EnumValue) packageName else "").toString() })
+            else CodeBlock.of("[\$L]", (value as ArrayValue).values.joinToString { v -> generateCode(config = config, value = v, annotationName = annotationName, prefix = if (v is EnumValue) prefix else "").toString() })
         else -> CodeBlock.of("\$L", value)
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -214,10 +214,17 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
         is BooleanValue -> CodeBlock.of("\$L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("\$L", (value as IntValue).value)
         is StringValue ->
-            // If string ends with .class, treat as class object
-            if ((value as StringValue).value.takeLast(6) == ".class") {
-                val className = (value as StringValue).value.dropLast(6)
+            // If string ends with .class or ::class, treat as Java Class
+            // Note: schema is universal and can be shared across java or kotlin code, hence both .class and ::class are supported
+            if ((value as StringValue).value.endsWith(ParserConstants.KOTLIN_CLASS)) {
+                val className = (value as StringValue).value.dropLast(ParserConstants.KOTLIN_CLASS_LENGTH)
                 // Use annotationName and className in the PackagerParserUtil to get Class Package name.
+                CodeBlock.of(
+                    "\$T.class",
+                    ClassName.get(PackageParserUtil.getClassPackage(config, annotationName, className), className)
+                )
+            } else if ((value as StringValue).value.endsWith(ParserConstants.JAVA_CLASS)) {
+                val className = (value as StringValue).value.dropLast(ParserConstants.JAVA_CLASS_LENGTH)
                 CodeBlock.of(
                     "\$T.class",
                     ClassName.get(PackageParserUtil.getClassPackage(config, annotationName, className), className)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -222,8 +222,7 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
                     "\$T.class",
                     ClassName.get(PackageParserUtil.getClassPackage(config, annotationName, className), className)
                 )
-            }
-            else CodeBlock.of("\$S", (value as StringValue).value)
+            } else CodeBlock.of("\$S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("\$L", (value as FloatValue).value)
         // In an enum value the prefix (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -319,17 +319,16 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
     when (value) {
         is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
-        // If string ends with ::class, treat as class object
         is StringValue ->
+            // If string ends with ::class, treat as class object
             if ((value as StringValue).value.takeLast(7) == "::class") {
                 val className = (value as StringValue).value.dropLast(7)
                 CodeBlock.of(
                     "$prefix%T::class",
-                     // Use annotationName in the PackagerParserUtil to get Class Package name.
+                    // Use annotationName and className in the PackagerParserUtil to get Class Package name.
                     ClassName(PackageParserUtil.getClassPackage(config, annotationName, className), className)
                 )
-            } else
-                CodeBlock.of("$prefix%S", (value as StringValue).value)
+            } else CodeBlock.of("$prefix%S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -319,7 +319,17 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
     when (value) {
         is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
-        is StringValue -> CodeBlock.of("$prefix%S", (value as StringValue).value)
+        // If string ends with ::class, treat as class object
+        is StringValue ->
+            if ((value as StringValue).value.takeLast(7) == "::class") {
+                val className = (value as StringValue).value.dropLast(7)
+                CodeBlock.of(
+                    "$prefix%T::class",
+                     // Use annotationName in the PackagerParserUtil to get Class Package name.
+                    ClassName(PackageParserUtil.getClassPackage(config, annotationName, className), className)
+                )
+            } else
+                CodeBlock.of("$prefix%S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -319,23 +319,17 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
     when (value) {
         is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
-        is StringValue ->
-            // If string ends with .class or ::class, treat as Kotlin KClass
-            // Note: schema is universal and can be shared across java or kotlin code, hence both .class and ::class are supported
-            if ((value as StringValue).value.endsWith(ParserConstants.KOTLIN_CLASS)) {
-                val className = (value as StringValue).value.dropLast(ParserConstants.KOTLIN_CLASS_LENGTH)
-                CodeBlock.of(
-                    "$prefix%T::class",
-                    // Use annotationName and className in the PackagerParserUtil to get Class Package name.
-                    ClassName(PackageParserUtil.getClassPackage(config, annotationName, className), className)
-                )
-            } else if ((value as StringValue).value.endsWith(ParserConstants.JAVA_CLASS)) {
-                val className = (value as StringValue).value.dropLast(ParserConstants.JAVA_CLASS_LENGTH)
-                CodeBlock.of(
-                    "$prefix%T::class",
-                    ClassName(PackageParserUtil.getClassPackage(config, annotationName, className), className)
-                )
-            } else CodeBlock.of("$prefix%S", (value as StringValue).value)
+        is StringValue -> {
+            // If string value ends with .class and classImports mapping is provided, treat as Kotlin KClass
+            val string = (value as StringValue).value
+            if (string.endsWith(ParserConstants.CLASS_STRING)) {
+                val className = string.dropLast(ParserConstants.CLASS_LENGTH)
+                // Use annotationName and className in the PackagerParserUtil to get Class Package name.
+                val classPackage = PackageParserUtil.getClassPackage(config, annotationName, className)
+                if (classPackage.isNotEmpty()) CodeBlock.of("$prefix%T::class", ClassName(classPackage, className))
+                else CodeBlock.of("$prefix%S", string)
+            } else CodeBlock.of("$prefix%S", string)
+        }
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         is EnumValue -> CodeBlock.of(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
@@ -27,7 +27,7 @@ class PackageParserUtil {
          * Retrieves the package value in the directive.
          * If not present uses the default package in the config for that particular type of annotation.
          * If neither of them are supplied the package name will be an empty String
-         * Also parses the  simpleName/className from the name argument in the directive
+         * Also parses the simpleName/className from the name argument in the directive
          */
         fun getAnnotationPackage(config: CodeGenConfig, name: String, type: String? = null): Pair<String, String> {
             var packageName = name.substringBeforeLast(".", "")
@@ -45,6 +45,13 @@ class PackageParserUtil {
         fun getEnumPackage(config: CodeGenConfig, annotationName: String, enumType: String): String {
             return config.includeEnumImports[annotationName]?.getOrDefault(
                 enumType,
+                ""
+            ) ?: ""
+        }
+
+        fun getClassPackage(config: CodeGenConfig, annotationName: String, className: String): String {
+            return config.includeClassImports[annotationName]?.getOrDefault(
+                className,
                 ""
             ) ?: ""
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
@@ -31,4 +31,8 @@ object ParserConstants {
     const val REPLACE_WITH = "replaceWith"
     const val REPLACE_WITH_CLASS = "ReplaceWith"
     const val SITE_TARGET = "target"
+    const val KOTLIN_CLASS = "::class"
+    const val JAVA_CLASS = ".class"
+    const val KOTLIN_CLASS_LENGTH = KOTLIN_CLASS.length
+    const val JAVA_CLASS_LENGTH = JAVA_CLASS.length
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
@@ -31,8 +31,6 @@ object ParserConstants {
     const val REPLACE_WITH = "replaceWith"
     const val REPLACE_WITH_CLASS = "ReplaceWith"
     const val SITE_TARGET = "target"
-    const val KOTLIN_CLASS = "::class"
-    const val JAVA_CLASS = ".class"
-    const val KOTLIN_CLASS_LENGTH = KOTLIN_CLASS.length
-    const val JAVA_CLASS_LENGTH = JAVA_CLASS.length
+    const val CLASS_STRING = ".class"
+    const val CLASS_LENGTH = CLASS_STRING.length
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3370,10 +3370,12 @@ It takes a title and such.
                 schemas = setOf(schema),
                 packageName = basePackageName,
                 includeImports = mapOf(Pair("validator", "com.test.validator")),
-                includeClassImports = mapOf("ValidPerson" to mapOf(
-                    Pair("BasicValidation", "com.test.validator.groups"),
-                    Pair("AdvanceValidation", "com.test.validator.groups")
-                )),
+                includeClassImports = mapOf(
+                    "ValidPerson" to mapOf(
+                        Pair("BasicValidation", "com.test.validator.groups"),
+                        Pair("AdvanceValidation", "com.test.validator.groups")
+                    )
+                ),
                 generateCustomAnnotations = true
             )
         ).generate()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3359,8 +3359,9 @@ It takes a title and such.
 
     @Test
     fun annotateOnTypesWithListOfClassObjects() {
+        // strings ending with .class or ::class will be treated as class objects and generate a Java Class
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation::class"]}) {
                 name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2160,8 +2160,9 @@ class KotlinCodeGenTest {
 
     @Test
     fun annotateOnTypesWithListOfClassObjects() {
+        // strings ending with .class or ::class will be treated as class objects and generate a Kotlin KClass
         val schema = """
-            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation::class","AdvanceValidation::class"]}) {
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation::class","AdvanceValidation.class"]}) {
                 name: String @annotate(name: "com.test.anotherValidator.ValidName")
             }
         """.trimIndent()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2172,10 +2172,12 @@ class KotlinCodeGenTest {
                 packageName = basePackageName,
                 language = Language.KOTLIN,
                 includeImports = mapOf(Pair("validator", "com.test.validator")),
-                includeClassImports = mapOf("ValidPerson" to mapOf(
-                    Pair("BasicValidation", "com.test.validator.groups"),
-                    Pair("AdvanceValidation", "com.test.validator.groups")
-                )),
+                includeClassImports = mapOf(
+                    "ValidPerson" to mapOf(
+                        Pair("BasicValidation", "com.test.validator.groups"),
+                        Pair("AdvanceValidation", "com.test.validator.groups")
+                    )
+                ),
                 generateCustomAnnotations = true
             )
         )

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -138,6 +138,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var includeEnumImports = mutableMapOf<String, MutableMap<String, String>>()
 
+    @Input
+    var includeClassImports = mutableMapOf<String, MutableMap<String, String>>()
+
     @TaskAction
     fun generate() {
         val schemaJarFilesFromDependencies = emptyList<File>().toMutableList()
@@ -194,6 +197,7 @@ open class GenerateJavaTask : DefaultTask() {
             addDeprecatedAnnotation = addDeprecatedAnnotation,
             includeImports = includeImports,
             includeEnumImports = includeEnumImports,
+            includeClassImports = includeClassImports,
             generateCustomAnnotations = generateCustomAnnotations
         )
 


### PR DESCRIPTION
**Add support for class objects as inputs for custom annotation.**

As per [Issue #476](https://github.com/Netflix/dgs-codegen/issues/476), updated custom annotation logic to interpret strings containing ".class" as class objects. 

Sample schema

```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation.class"}) {
  name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```
Sample generated class

```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import com.test.validator.groups.BasicValidation
import kotlin.String

@ValidPerson(groups = BasicValidation::class)
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null,
) {
  public companion object
}
```
Sample schema

```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
  name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```
Sample generated class

```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import kotlin.String

@ValidPerson(groups = [com.test.validator.groups.BasicValidation::class, com.test.validator.groups.AdvanceValidation::class])
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null,
) {
  public companion object
}
```